### PR TITLE
MARSClient Run-Time & Design-Time division

### DIFF
--- a/Packages/102Tokyo/MARSClient.Core.dpk
+++ b/Packages/102Tokyo/MARSClient.Core.dpk
@@ -28,7 +28,7 @@ package MARSClient.Core;
 {$ENDIF IMPLICITBUILDING}
 {$DESCRIPTION 'MARS-Curiosity Client Core'}
 {$LIBSUFFIX '250'}
-{$DESIGNONLY}
+{$RUNONLY}
 {$IMPLICITBUILD OFF}
 
 requires
@@ -38,14 +38,11 @@ requires
   IndySystem,
   IndyProtocols,
   IndyCore,
-  bindengine,
-  bindcomp,
   MARS.Utils;
 
 contains
   MARS.Client.Application in '..\..\Source\MARS.Client.Application.pas',
   MARS.Client.Client.Net in '..\..\Source\MARS.Client.Client.Net.pas',
-  MARS.Client.CustomResource.Editor in '..\..\Source\MARS.Client.CustomResource.Editor.pas',
   MARS.Client.CustomResource in '..\..\Source\MARS.Client.CustomResource.pas',
   MARS.Client.Messaging.Resource in '..\..\Source\MARS.Client.Messaging.Resource.pas',
   MARS.Client.Resource.JSON in '..\..\Source\MARS.Client.Resource.JSON.pas',
@@ -55,7 +52,6 @@ contains
   MARS.Client.SubResource in '..\..\Source\MARS.Client.SubResource.pas',
   MARS.Client.SubResource.Stream in '..\..\Source\MARS.Client.SubResource.Stream.pas',
   MARS.Client.Token in '..\..\Source\MARS.Client.Token.pas',
-  MARS.Client.Utils.LiveBindings in '..\..\Source\MARS.Client.Utils.LiveBindings.pas',
   MARS.Client.Utils in '..\..\Source\MARS.Client.Utils.pas',
   MARS.Client.Client in '..\..\Source\MARS.Client.Client.pas',
   MARS.Client.Client.Indy in '..\..\Source\MARS.Client.Client.Indy.pas',

--- a/Packages/102Tokyo/MARSClient.CoreDesign.dpk
+++ b/Packages/102Tokyo/MARSClient.CoreDesign.dpk
@@ -1,4 +1,4 @@
-package MARSClient.FireDAC;
+package MARSClient.CoreDesign;
 
 {$R *.res}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
@@ -25,25 +25,22 @@ package MARSClient.FireDAC;
 {$IMAGEBASE $400000}
 {$DEFINE DEBUG}
 {$ENDIF IMPLICITBUILDING}
-{$DESCRIPTION 'MARS-Curiosity Client FireDAC'}
+{$DESCRIPTION 'MARS-Curiosity Client Core'}
 {$LIBSUFFIX '250'}
-{$RUNONLY}
+{$DESIGNONLY}
 {$IMPLICITBUILD OFF}
 
 requires
-  rtl,
-  MARSClient.Core,
-  FireDAC,
-  FireDACCommonDriver,
-  FireDACCommon;
+  bindengine,
+  bindcomp,
+  MARSClient.Core;
 
 contains
-  MARS.Client.FireDAC in '..\..\Source\MARS.Client.FireDAC.pas',
-  MARS.Data.FireDAC.Utils in '..\..\Source\MARS.Data.FireDAC.Utils.pas';
+  MARS.Client.Utils.LiveBindings in '..\..\Source\MARS.Client.Utils.LiveBindings.pas',
+  MARS.Client.Register in '..\..\Source\MARS.Client.Register.pas',
+  MARS.Client.CustomResource.Editor in '..\..\Source\MARS.Client.CustomResource.Editor.pas';
 
 end.
-
-
 
 
 

--- a/Packages/102Tokyo/MARSClient.CoreDesign.dproj
+++ b/Packages/102Tokyo/MARSClient.CoreDesign.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <ProjectGuid>{48E75129-EE24-48D4-AE54-2F549C909CC8}</ProjectGuid>
-        <MainSource>MARSClient.Core.dpk</MainSource>
+        <ProjectGuid>{8EEA5DAB-B80F-44EA-B149-45D051C20610}</ProjectGuid>
+        <MainSource>MARSClient.CoreDesign.dpk</MainSource>
         <ProjectVersion>18.3</ProjectVersion>
         <FrameworkType>FMX</FrameworkType>
         <Base>True</Base>
@@ -46,7 +46,7 @@
         <DCC_AdditionalSwitches>-LUDesignIDE</DCC_AdditionalSwitches>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;Vcl;$(DCC_Namespace)</DCC_Namespace>
         <GenPackage>true</GenPackage>
-        <SanitizedProjectName>MARSClient_Core</SanitizedProjectName>
+        <SanitizedProjectName>MARSClient_CoreDesign</SanitizedProjectName>
         <GenDll>true</GenDll>
         <DCC_DcuOutput>..\..\Lib250\$(Platform)\$(Config)</DCC_DcuOutput>
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
@@ -57,11 +57,11 @@
         <DCC_K>false</DCC_K>
         <VerInfo_Locale>2057</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
-        <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
         <DCC_OutputNeverBuildDcps>true</DCC_OutputNeverBuildDcps>
+        <DesignOnlyPackage>true</DesignOnlyPackage>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
-        <DCC_UsePackage>rtl;inet;DbxCommonDriver;dbrtl;FireDACCommon;FireDACCommonDriver;FireDAC;DataSnapFireDAC;IndySystem;IndyProtocols;IndyCore;bindengine;bindcomp;MARS.Utils;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_UsePackage>rtl;inet;DbxCommonDriver;dbrtl;FireDACCommon;FireDACCommonDriver;FireDAC;DataSnapFireDAC;IndySystem;IndyProtocols;IndyCore;bindengine;bindcomp;MARS.Utils;MARSClient.Core;$(DCC_UsePackage)</DCC_UsePackage>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(ModuleName);FileDescription=$(ModuleName);ProductName=$(ModuleName)</VerInfo_Keys>
@@ -100,76 +100,12 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="rtl.dcp"/>
-        <DCCReference Include="dbrtl.dcp"/>
-        <DCCReference Include="inet.dcp"/>
-        <DCCReference Include="IndySystem.dcp"/>
-        <DCCReference Include="IndyProtocols.dcp"/>
-        <DCCReference Include="IndyCore.dcp"/>
-        <DCCReference Include="MARS.Utils.dcp"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Application.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.Net.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.CustomResource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Messaging.Resource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.JSON.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.Stream.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.JSON.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.Stream.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Token.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Utils.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.Indy.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.FormData.pas"/>
-        <RcItem Include="..\..\media\TMARSClientMessagingResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTMESSAGINGRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceJSON.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCEJSON</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceStream.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCESTREAM</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResourceJSON.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCEJSON</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResourceStream.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCESTREAM</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientToken.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTTOKEN</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClient.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENT</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientApplication.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTAPPLICATION</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSNetClient.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSNETCLIENT</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceFormData.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCEFORMDATA</ResourceId>
-        </RcItem>
+        <DCCReference Include="bindengine.dcp"/>
+        <DCCReference Include="bindcomp.dcp"/>
+        <DCCReference Include="MARSClient.Core.dcp"/>
+        <DCCReference Include="..\..\Source\MARS.Client.Utils.LiveBindings.pas"/>
+        <DCCReference Include="..\..\Source\MARS.Client.Register.pas"/>
+        <DCCReference Include="..\..\Source\MARS.Client.CustomResource.Editor.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -188,7 +124,7 @@
         <BorlandProject>
             <Delphi.Personality>
                 <Source>
-                    <Source Name="MainSource">MARSClient.Core.dpk</Source>
+                    <Source Name="MainSource">MARSClient.CoreDesign.dpk</Source>
                 </Source>
                 <Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k250.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
@@ -221,9 +157,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="..\..\..\..\Bpl\MARSClient.Core250.bpl" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="..\..\..\..\Bpl\MARSClient.CoreDesign250.bpl" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
-                        <RemoteName>MARSClient_Core.bpl</RemoteName>
+                        <RemoteName>MARSClient_CoreDesign.bpl</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/Packages/102Tokyo/MARSClient.Enterprise.groupproj
+++ b/Packages/102Tokyo/MARSClient.Enterprise.groupproj
@@ -9,7 +9,13 @@
         <Projects Include="MARSClient.Core.dproj">
             <Dependencies/>
         </Projects>
+        <Projects Include="MARSClient.CoreDesign.dproj">
+            <Dependencies/>
+        </Projects>
         <Projects Include="MARSClient.FireDAC.dproj">
+            <Dependencies/>
+        </Projects>
+        <Projects Include="MARSClient.FireDACDesign.dproj">
             <Dependencies/>
         </Projects>
     </ItemGroup>
@@ -38,6 +44,15 @@
     <Target Name="MARSClient_Core:Make">
         <MSBuild Projects="MARSClient.Core.dproj" Targets="Make"/>
     </Target>
+    <Target Name="MARSClient_CoreDesign">
+        <MSBuild Projects="MARSClient.CoreDesign.dproj"/>
+    </Target>
+    <Target Name="MARSClient_CoreDesign:Clean">
+        <MSBuild Projects="MARSClient.CoreDesign.dproj" Targets="Clean"/>
+    </Target>
+    <Target Name="MARSClient_CoreDesign:Make">
+        <MSBuild Projects="MARSClient.CoreDesign.dproj" Targets="Make"/>
+    </Target>
     <Target Name="MARSClient_FireDAC">
         <MSBuild Projects="MARSClient.FireDAC.dproj"/>
     </Target>
@@ -47,14 +62,23 @@
     <Target Name="MARSClient_FireDAC:Make">
         <MSBuild Projects="MARSClient.FireDAC.dproj" Targets="Make"/>
     </Target>
+    <Target Name="MARSClient_FireDACDesign">
+        <MSBuild Projects="MARSClient.FireDACDesign.dproj"/>
+    </Target>
+    <Target Name="MARSClient_FireDACDesign:Clean">
+        <MSBuild Projects="MARSClient.FireDACDesign.dproj" Targets="Clean"/>
+    </Target>
+    <Target Name="MARSClient_FireDACDesign:Make">
+        <MSBuild Projects="MARSClient.FireDACDesign.dproj" Targets="Make"/>
+    </Target>
     <Target Name="Build">
-        <CallTarget Targets="MARS_Utils;MARSClient_Core;MARSClient_FireDAC"/>
+        <CallTarget Targets="MARS_Utils;MARSClient_Core;MARSClient_CoreDesign;MARSClient_FireDAC;MARSClient_FireDACDesign"/>
     </Target>
     <Target Name="Clean">
-        <CallTarget Targets="MARS_Utils:Clean;MARSClient_Core:Clean;MARSClient_FireDAC:Clean"/>
+        <CallTarget Targets="MARS_Utils:Clean;MARSClient_Core:Clean;MARSClient_CoreDesign:Clean;MARSClient_FireDAC:Clean;MARSClient_FireDACDesign:Clean"/>
     </Target>
     <Target Name="Make">
-        <CallTarget Targets="MARS_Utils:Make;MARSClient_Core:Make;MARSClient_FireDAC:Make"/>
+        <CallTarget Targets="MARS_Utils:Make;MARSClient_Core:Make;MARSClient_CoreDesign:Make;MARSClient_FireDAC:Make;MARSClient_FireDACDesign:Make"/>
     </Target>
     <Import Project="$(BDS)\Bin\CodeGear.Group.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Group.Targets')"/>
 </Project>

--- a/Packages/102Tokyo/MARSClient.FireDAC.dproj
+++ b/Packages/102Tokyo/MARSClient.FireDAC.dproj
@@ -36,7 +36,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
         <DllSuffix>240</DllSuffix>
-        <DesignOnlyPackage>true</DesignOnlyPackage>
         <DCC_UnitSearchPath>../../Source/Core;../../Source/Data/FireDAC;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <DCC_Description>MARS-Curiosity REST Library (Client)</DCC_Description>
         <DCC_AdditionalSwitches>-LUDesignIDE</DCC_AdditionalSwitches>
@@ -53,6 +52,7 @@
         <DCC_K>false</DCC_K>
         <VerInfo_Locale>2057</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
+        <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
         <DCC_OutputNeverBuildDcps>true</DCC_OutputNeverBuildDcps>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
@@ -76,6 +76,7 @@
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(ModuleName);FileDescription=$(ModuleName);ProductName=$(ModuleName)</VerInfo_Keys>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
@@ -93,7 +94,6 @@
         <DCCReference Include="FireDACCommonDriver.dcp"/>
         <DCCReference Include="FireDACCommon.dcp"/>
         <DCCReference Include="..\..\Source\MARS.Client.FireDAC.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Data.FireDAC.Editor.pas"/>
         <DCCReference Include="..\..\Source\MARS.Data.FireDAC.Utils.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
@@ -116,6 +116,8 @@
                     <Source Name="MainSource">MARSClient.FireDAC.dpk</Source>
                 </Source>
                 <Excluded_Packages>
+                    <Excluded_Packages Name="C:\dev\delphi\Bpl\MARSClient.Core250.bpl">MARS-Curiosity Client Core</Excluded_Packages>
+                    <Excluded_Packages Name="C:\dev\delphi\Bpl\MARSClient.FireDAC250.bpl">MARS-Curiosity Client FireDAC</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k250.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dclofficexp250.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
                 </Excluded_Packages>
@@ -146,7 +148,7 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="C:\Users\Public\Documents\Embarcadero\Studio\19.0\Bpl\MARSClient.FireDAC250.bpl" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="..\..\..\..\Bpl\MARSClient.FireDAC250.bpl" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>MARSClient_FireDAC.bpl</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/Packages/102Tokyo/MARSClient.FireDACDesign.dpk
+++ b/Packages/102Tokyo/MARSClient.FireDACDesign.dpk
@@ -1,4 +1,4 @@
-package MARSClient.FireDAC;
+package MARSClient.FireDACDesign;
 
 {$R *.res}
 {$IFDEF IMPLICITBUILDING This IFDEF should not be used by users}
@@ -27,19 +27,16 @@ package MARSClient.FireDAC;
 {$ENDIF IMPLICITBUILDING}
 {$DESCRIPTION 'MARS-Curiosity Client FireDAC'}
 {$LIBSUFFIX '250'}
-{$RUNONLY}
+{$DESIGNONLY}
 {$IMPLICITBUILD OFF}
 
 requires
-  rtl,
-  MARSClient.Core,
-  FireDAC,
-  FireDACCommonDriver,
-  FireDACCommon;
+  MARSClient.FireDAC,
+  MARSClient.CoreDesign;
 
 contains
-  MARS.Client.FireDAC in '..\..\Source\MARS.Client.FireDAC.pas',
-  MARS.Data.FireDAC.Utils in '..\..\Source\MARS.Data.FireDAC.Utils.pas';
+  MARS.Data.FireDAC.Editor in '..\..\Source\MARS.Data.FireDAC.Editor.pas',
+  MARS.Client.FireDAC.Register in '..\..\Source\MARS.Client.FireDAC.Register.pas';
 
 end.
 

--- a/Packages/102Tokyo/MARSClient.FireDACDesign.dproj
+++ b/Packages/102Tokyo/MARSClient.FireDACDesign.dproj
@@ -1,13 +1,13 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <ProjectGuid>{48E75129-EE24-48D4-AE54-2F549C909CC8}</ProjectGuid>
-        <MainSource>MARSClient.Core.dpk</MainSource>
+        <ProjectGuid>{6F52BB40-74E2-410E-A54D-0C20E713A0CE}</ProjectGuid>
+        <MainSource>MARSClient.FireDACDesign.dpk</MainSource>
         <ProjectVersion>18.3</ProjectVersion>
         <FrameworkType>FMX</FrameworkType>
         <Base>True</Base>
         <Config Condition="'$(Config)'==''">Debug</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
-        <TargetedPlatforms>3</TargetedPlatforms>
+        <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Package</AppType>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -15,11 +15,6 @@
     </PropertyGroup>
     <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
         <Base_Win32>true</Base_Win32>
-        <CfgParent>Base</CfgParent>
-        <Base>true</Base>
-    </PropertyGroup>
-    <PropertyGroup Condition="('$(Platform)'=='Win64' and '$(Base)'=='true') or '$(Base_Win64)'!=''">
-        <Base_Win64>true</Base_Win64>
         <CfgParent>Base</CfgParent>
         <Base>true</Base>
     </PropertyGroup>
@@ -41,12 +36,13 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base)'!=''">
         <DllSuffix>240</DllSuffix>
+        <DesignOnlyPackage>true</DesignOnlyPackage>
         <DCC_UnitSearchPath>../../Source/Core;../../Source/Data/FireDAC;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <DCC_Description>MARS-Curiosity REST Library (Client)</DCC_Description>
         <DCC_AdditionalSwitches>-LUDesignIDE</DCC_AdditionalSwitches>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;Vcl;$(DCC_Namespace)</DCC_Namespace>
         <GenPackage>true</GenPackage>
-        <SanitizedProjectName>MARSClient_Core</SanitizedProjectName>
+        <SanitizedProjectName>MARSClient_FireDACDesign</SanitizedProjectName>
         <GenDll>true</GenDll>
         <DCC_DcuOutput>..\..\Lib250\$(Platform)\$(Config)</DCC_DcuOutput>
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
@@ -57,22 +53,14 @@
         <DCC_K>false</DCC_K>
         <VerInfo_Locale>2057</VerInfo_Locale>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName);FileDescription=$(MSBuildProjectName);ProductName=$(MSBuildProjectName)</VerInfo_Keys>
-        <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
         <DCC_OutputNeverBuildDcps>true</DCC_OutputNeverBuildDcps>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
-        <DCC_UsePackage>rtl;inet;DbxCommonDriver;dbrtl;FireDACCommon;FireDACCommonDriver;FireDAC;DataSnapFireDAC;IndySystem;IndyProtocols;IndyCore;bindengine;bindcomp;MARS.Utils;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_UsePackage>rtl;inet;DbxCommonDriver;dbrtl;FireDACCommon;FireDACCommonDriver;FireDAC;DataSnapFireDAC;IndySystem;IndyProtocols;IndyCore;bindengine;bindcomp;MARSClient.FireDAC;$(DCC_UsePackage)</DCC_UsePackage>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(ModuleName);FileDescription=$(ModuleName);ProductName=$(ModuleName)</VerInfo_Keys>
         <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Base_Win64)'!=''">
-        <DCC_UsePackage>rtl;inet;DbxCommonDriver;dbrtl;FireDACCommon;FireDACCommonDriver;FireDAC;DataSnapFireDAC;IndySystem;IndyProtocols;IndyCore;bindengine;bindcomp;MARS.Utils;$(DCC_UsePackage)</DCC_UsePackage>
-        <VerInfo_Locale>1033</VerInfo_Locale>
-        <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <VerInfo_Keys>CompanyName=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductVersion=1.0.0.0;Comments=;ProgramID=com.embarcadero.$(ModuleName);FileDescription=$(ModuleName);ProductName=$(ModuleName)</VerInfo_Keys>
-        <DCC_Namespace>System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;$(DCC_Namespace)</DCC_Namespace>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
@@ -84,7 +72,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <DllSuffix>250</DllSuffix>
-        <DCC_Description>MARS-Curiosity Client Core</DCC_Description>
+        <DCC_Description>MARS-Curiosity Client FireDAC</DCC_Description>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
@@ -100,76 +88,10 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="rtl.dcp"/>
-        <DCCReference Include="dbrtl.dcp"/>
-        <DCCReference Include="inet.dcp"/>
-        <DCCReference Include="IndySystem.dcp"/>
-        <DCCReference Include="IndyProtocols.dcp"/>
-        <DCCReference Include="IndyCore.dcp"/>
-        <DCCReference Include="MARS.Utils.dcp"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Application.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.Net.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.CustomResource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Messaging.Resource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.JSON.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.Stream.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.JSON.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.SubResource.Stream.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Token.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Utils.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Client.Indy.pas"/>
-        <DCCReference Include="..\..\Source\MARS.Client.Resource.FormData.pas"/>
-        <RcItem Include="..\..\media\TMARSClientMessagingResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTMESSAGINGRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceJSON.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCEJSON</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceStream.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCESTREAM</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResource.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCE</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResourceJSON.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCEJSON</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientSubResourceStream.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTSUBRESOURCESTREAM</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientToken.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTTOKEN</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClient.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENT</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientApplication.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTAPPLICATION</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSNetClient.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSNETCLIENT</ResourceId>
-        </RcItem>
-        <RcItem Include="..\..\media\TMARSClientResourceFormData.bmp">
-            <ResourceType>BITMAP</ResourceType>
-            <ResourceId>TMARSCLIENTRESOURCEFORMDATA</ResourceId>
-        </RcItem>
+        <DCCReference Include="MARSClient.FireDAC.dcp"/>
+        <DCCReference Include="MARSClient.CoreDesign.dcp"/>
+        <DCCReference Include="..\..\Source\MARS.Data.FireDAC.Editor.pas"/>
+        <DCCReference Include="..\..\Source\MARS.Client.FireDAC.Register.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -188,7 +110,7 @@
         <BorlandProject>
             <Delphi.Personality>
                 <Source>
-                    <Source Name="MainSource">MARSClient.Core.dpk</Source>
+                    <Source Name="MainSource">MARSClient.FireDACDesign.dpk</Source>
                 </Source>
                 <Excluded_Packages>
                     <Excluded_Packages Name="$(BDSBIN)\dcloffice2k250.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
@@ -221,9 +143,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="..\..\..\..\Bpl\MARSClient.Core250.bpl" Configuration="Debug" Class="ProjectOutput">
+                <DeployFile LocalName="..\..\..\..\Bpl\MARSClient.FireDACDesign250.bpl" Configuration="Debug" Class="ProjectOutput">
                     <Platform Name="Win32">
-                        <RemoteName>MARSClient_Core.bpl</RemoteName>
+                        <RemoteName>MARSClient_FireDACDesign.bpl</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -588,7 +510,6 @@
             </Deployment>
             <Platforms>
                 <Platform value="Win32">True</Platform>
-                <Platform value="Win64">True</Platform>
             </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>

--- a/Source/MARS.Client.Application.pas
+++ b/Source/MARS.Client.Application.pas
@@ -54,18 +54,11 @@ type
     property OnError: TMARSClientErrorEvent read FOnError write FOnError;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.URL, MARS.Core.MediaType
   ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientApplication]);
-end;
 
 { TMARSClientApplication }
 

--- a/Source/MARS.Client.Client.Indy.pas
+++ b/Source/MARS.Client.Client.Indy.pas
@@ -85,8 +85,6 @@ type
 
   TMARSClient = class(TMARSIndyClient); // compatibility
 
-procedure Register;
-
 implementation
 
 uses
@@ -97,11 +95,6 @@ uses
   , MARS.Client.Resource.Stream
   , MARS.Client.Application
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClient]);
-end;
 
 { TMARSIndyClient }
 

--- a/Source/MARS.Client.Client.Net.pas
+++ b/Source/MARS.Client.Client.Net.pas
@@ -79,8 +79,6 @@ type
     property HttpClient: TNetHTTPClient read FHttpClient;
   end;
 
-procedure Register;
-
 implementation
 
 uses
@@ -91,11 +89,6 @@ uses
   , MARS.Client.Resource.Stream
   , MARS.Client.Application
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSNetClient]);
-end;
 
 { TMARSNetClient }
 

--- a/Source/MARS.Client.CustomResource.Editor.pas
+++ b/Source/MARS.Client.CustomResource.Editor.pas
@@ -25,8 +25,6 @@ type
     function GetVerbCount: Integer; override;
   end;
 
-procedure Register;
-
 implementation
 
 uses
@@ -35,13 +33,7 @@ uses
 {$else}
   Dialogs
 {$endif}
-  , DesignIntf
   , Windows, IdHTTP;
-
-procedure Register;
-begin
-  RegisterComponentEditor(TMARSClientCustomResource, TMARSClientCustomResourceEditor);
-end;
 
 { TMARSClientCustomResourceEditor }
 

--- a/Source/MARS.Client.FireDAC.Register.pas
+++ b/Source/MARS.Client.FireDAC.Register.pas
@@ -1,0 +1,19 @@
+unit MARS.Client.FireDAC.Register;
+
+interface
+
+procedure Register;
+
+implementation
+
+uses
+  Classes, DesignIntf,
+  MARS.Client.FireDAC, MARS.Data.FireDAC.Editor;
+
+procedure Register;
+begin
+  RegisterComponents('MARS-Curiosity Client', [TMARSFDResource]);
+  RegisterComponentEditor(TMARSFDResource, TMARSFDResourceEditor);
+end;
+
+end.

--- a/Source/MARS.Client.FireDAC.pas
+++ b/Source/MARS.Client.FireDAC.pas
@@ -82,8 +82,6 @@ type
     property ApplyUpdatesResults: TArray<TMARSFDApplyUpdatesRes> read FApplyUpdatesResults;
   end;
 
-procedure Register;
-
 implementation
 
 uses
@@ -92,11 +90,6 @@ uses
   , MARS.Core.Utils, MARS.Client.Utils, MARS.Rtti.Utils
   , MARS.Core.Exceptions, MARS.Core.MediaType
   ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSFDResource]);
-end;
 
 { TMARSFDResource }
 

--- a/Source/MARS.Client.Messaging.Resource.pas
+++ b/Source/MARS.Client.Messaging.Resource.pas
@@ -52,14 +52,7 @@ type
     property OnMessage: TMARSMessageEvent read FOnMessage write FOnMessage;
   end;
 
-procedure Register;
-
 implementation
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientMessagingResource]);
-end;
 
 { TMARSClientMessagingResource }
 

--- a/Source/MARS.Client.Register.pas
+++ b/Source/MARS.Client.Register.pas
@@ -1,0 +1,34 @@
+unit MARS.Client.Register;
+
+interface
+
+procedure Register;
+
+implementation
+
+uses
+  Classes, DesignIntf,
+  MARS.Client.Client.Indy, MARS.Client.Application, MARS.Client.Messaging.Resource,
+  MARS.Client.Resource, MARS.Client.Resource.FormData, MARS.Client.Resource.JSON,
+  MARS.Client.Resource.Stream, MARS.Client.SubResource, MARS.Client.SubResource.JSON,
+  MARS.Client.SubResource.Stream, MARS.Client.Token, MARS.Client.Client.Net,
+  MARS.Client.CustomResource, MARS.Client.CustomResource.Editor;
+
+procedure Register;
+begin
+  RegisterComponents('MARS-Curiosity Client', [TMARSClient,
+                                               TMARSClientApplication,
+                                               TMARSClientMessagingResource,
+                                               TMARSClientResource,
+                                               TMARSClientResourceFormData,
+                                               TMARSClientResourceJSON,
+                                               TMARSClientResourceStream,
+                                               TMARSClientSubResource,
+                                               TMARSClientSubResourceJSON,
+                                               TMARSClientSubResourceStream,
+                                               TMARSClientToken,
+                                               TMARSNetClient]);
+  RegisterComponentEditor(TMARSClientCustomResource, TMARSClientCustomResourceEditor);
+end;
+
+end.

--- a/Source/MARS.Client.Resource.FormData.pas
+++ b/Source/MARS.Client.Resource.FormData.pas
@@ -63,18 +63,11 @@ type
     property ResponseAsString: string read GetResponseAsString;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.MediaType
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientResourceFormData]);
-end;
 
 { TMARSClientResourceFormData }
 

--- a/Source/MARS.Client.Resource.JSON.pas
+++ b/Source/MARS.Client.Resource.JSON.pas
@@ -88,18 +88,11 @@ type
     property ResponseAsString: string read GetResponseAsString;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.Utils, MARS.Core.MediaType
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientResourceJSON]);
-end;
 
 { TMARSClientResourceJSON }
 

--- a/Source/MARS.Client.Resource.Stream.pas
+++ b/Source/MARS.Client.Resource.Stream.pas
@@ -50,18 +50,11 @@ type
     property ResponseSize: Int64 read GetResponseSize;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.Utils,
   MARS.Core.MediaType;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientResourceStream]);
-end;
 
 { TMARSClientResourceStream }
 

--- a/Source/MARS.Client.Resource.pas
+++ b/Source/MARS.Client.Resource.pas
@@ -47,13 +47,6 @@ type
     property Token;
   end;
 
-procedure Register;
-
 implementation
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientResource]);
-end;
 
 end.

--- a/Source/MARS.Client.SubResource.JSON.pas
+++ b/Source/MARS.Client.SubResource.JSON.pas
@@ -46,18 +46,11 @@ type
     property ResponseAsString: string read GetResponseAsString;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.Utils, MARS.Core.MediaType
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientSubResourceJSON]);
-end;
 
 { TMARSClientResourceJSON }
 

--- a/Source/MARS.Client.SubResource.Stream.pas
+++ b/Source/MARS.Client.SubResource.Stream.pas
@@ -45,18 +45,11 @@ type
     property ResponseSize: Int64 read GetResponseSize;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   MARS.Core.Utils,
   MARS.Core.MediaType;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientSubResourceStream]);
-end;
 
 { TMARSClientResourceJSON }
 

--- a/Source/MARS.Client.SubResource.pas
+++ b/Source/MARS.Client.SubResource.pas
@@ -47,18 +47,11 @@ type
     property ParentResource: TMARSClientResource read FParentResource write FParentResource;
   end;
 
-procedure Register;
-
 implementation
 
 uses
     MARS.Client.Utils
   , MARS.Core.URL;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientSubResource]);
-end;
 
 { TMARSClientSubResource }
 

--- a/Source/MARS.Client.Token.pas
+++ b/Source/MARS.Client.Token.pas
@@ -74,8 +74,6 @@ type
     property IsExpired: Boolean read GetIsExpired;
   end;
 
-procedure Register;
-
 implementation
 
 uses
@@ -83,11 +81,6 @@ uses
 , MARS.Core.Utils, MARS.Rtti.Utils
 , MARS.Core.MediaType
 ;
-
-procedure Register;
-begin
-  RegisterComponents('MARS-Curiosity Client', [TMARSClientToken]);
-end;
 
 { TMARSClientToken }
 

--- a/Source/MARS.Data.FireDAC.Editor.pas
+++ b/Source/MARS.Data.FireDAC.Editor.pas
@@ -25,22 +25,13 @@ type
     function GetVerbCount: Integer; override;
   end;
 
-procedure Register;
-
 implementation
 
 uses
   Windows
   , VCL.Dialogs
-  , DesignIntf
-
   , FireDAC.Comp.Client
 ;
-
-procedure Register;
-begin
-  RegisterComponentEditor(TMARSFDResource, TMARSFDResourceEditor);
-end;
 
 { TMARSFDResourceEditor }
 


### PR DESCRIPTION
This appear appropiate.
So u don't need to distribute bindcomp250.bpl, bindengine250.bpl, designide250.bpl and  vclactnband250.bpl in application with packages at run-time.

Done for Delphi.10.2.2/3 Tokio
