### PR TITLE
Error "TestInsight.DUnitX not found" when compiling MARSTestsProject.dpr

### DIFF
--- a/tests/MARSTestsProject.dpr
+++ b/tests/MARSTestsProject.dpr
@@ -10,7 +10,9 @@ program MARSTestsProject;
 
 uses
   SysUtils,
+{$IFDEF TESTINSIGHT}
   TestInsight.DUnitX,
+{$ENDIF}
   DUnitX.TestFramework,
   DUnitX.Loggers.Console,
   Tests.Core in 'Tests.Core.pas',


### PR DESCRIPTION
A {$IFDEF TESTINSIGHT} is missing in the MARSTestsProject.dpr project file.