### PR TITLE
Update Linux Delphi Tokyo / Generater Files nonshared.a .res

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ Android
 
 # OS X Internal file
 .DS_Store
+*.res
+*_nonshared.a

--- a/Packages/102Tokyo/MARS.FireDAC.dproj
+++ b/Packages/102Tokyo/MARS.FireDAC.dproj
@@ -526,7 +526,9 @@
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>
+                <Platform value="Linux64">True</Platform>
                 <Platform value="Win32">True</Platform>
+                <Platform value="Win64">True</Platform>
             </Platforms>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>

--- a/Packages/102Tokyo/MARS.JOSE.dproj
+++ b/Packages/102Tokyo/MARS.JOSE.dproj
@@ -562,6 +562,7 @@
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>
+                <Platform value="Linux64">True</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
             </Platforms>

--- a/Packages/102Tokyo/MARS.mORMot.dproj
+++ b/Packages/102Tokyo/MARS.mORMot.dproj
@@ -555,7 +555,6 @@
                 <ProjectRoot Platform="iOSSimulator" Name="$(PROJECTNAME).app"/>
             </Deployment>
             <Platforms>
-                <Platform value="Linux64">True</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>
             </Platforms>


### PR DESCRIPTION
MARS.mORMot Its not suported for Linux64
MARS.FireDAC suported for Linux64
MARS.JOSE suported for Linux64