### PR TITLE
Changes to unit for CodeSiteLogging

### DIFF
--- a/Source/MARS.Utils.ReqRespLogger.CodeSite.pas
+++ b/Source/MARS.Utils.ReqRespLogger.CodeSite.pas
@@ -109,16 +109,19 @@ begin
         Exit;
 
       LRequest := TMARSRequestLogCodeSite.Create(AR.Request);
-      TMARSReqRespLoggerCodeSite.Instance.Log(
-        String.Join(LOGFIELD_SEPARATOR,
-          [
-           'Incoming',
-           'Engine: ' + AR.Engine.Name,
-           'Application: ' + AR.Application.Name
-          ]
-        ), LRequest
-      );
-      LRequest.Free;
+      try
+        TMARSReqRespLoggerCodeSite.Instance.Log(
+          String.Join(LOGFIELD_SEPARATOR,
+            [
+             'Incoming',
+             'Engine: ' + AR.Engine.Name,
+             'Application: ' + AR.Application.Name
+            ]
+          ), LRequest
+        );
+      finally
+        LRequest.Free;
+      end;
     end
   );
 
@@ -131,17 +134,20 @@ begin
         Exit;
 
       LResponse := TMARSResponseLogCodeSite.Create(AR.Response);
-      TMARSReqRespLoggerCodeSite.Instance.Log(
-        string.Join(LOGFIELD_SEPARATOR
-        , [
-            'Outgoing'
-          , 'Time: ' + AR.InvocationTime.ElapsedMilliseconds.ToString + ' ms'
-          , 'Engine: ' + AR.Engine.Name
-          , 'Application: ' + AR.Application.Name
-          ]
-        ), LResponse
-      );
-      LResponse.Free;
+      try
+        TMARSReqRespLoggerCodeSite.Instance.Log(
+          string.Join(LOGFIELD_SEPARATOR
+          , [
+              'Outgoing'
+            , 'Time: ' + AR.InvocationTime.ElapsedMilliseconds.ToString + ' ms'
+            , 'Engine: ' + AR.Engine.Name
+            , 'Application: ' + AR.Application.Name
+            ]
+          ), LResponse
+        );
+      finally
+        LResponse.Free;
+      end;
     end
   );
 end;

--- a/Source/MARS.Utils.ReqRespLogger.CodeSite.pas
+++ b/Source/MARS.Utils.ReqRespLogger.CodeSite.pas
@@ -19,8 +19,6 @@ uses
   MARS.Core.Activation.Interfaces,
   MARS.Utils.ReqRespLogger.Interfaces,
   MARS.Core.RequestAndResponse.Interfaces,
-  //MARS.http.Server.DCS,
-  MARS.http.Server.Indy,
   CodeSiteLogging;
 
 type
@@ -191,10 +189,7 @@ end;
 { TMARSRequestLoggerCodeSite }
 
 constructor TMARSRequestLogCodeSite.Create(ARequest: IMARSRequest);
-var
-  LRequest: TMARSWebRequest;
 begin
-  //IMARSRequest
   FAccept := ARequest.Accept;
   FAuthorization := ARequest.Authorization;
   FHostName := ARequest.HostName;
@@ -209,13 +204,6 @@ begin
   FContentType := ARequest.GetHeaderParamValue('Content-Type');
   FContentEncoding := ARequest.GetHeaderParamValue('Content-Encoding');
   FContentLength := ARequest.GetHeaderParamValue('Content-Length');
-
-  if ARequest.AsObject is TMARSWebRequest then
-  begin
-    //TWebRequest
-    LRequest := TMARSWebRequest(ARequest.AsObject);
-    FRemoteAddr := LRequest.WebRequest.RemoteAddr;
-  end;
 end;
 
 { TMARSResponseLoggerCodeSite }


### PR DESCRIPTION
Hi Andrea, 

I updated the unit for CodeSiteLogging, which did not support the IMARSResponse and IMARSRequest interface.

Instead of formatting a message, I created simple log-objects and sends the whole object to CodeSite. 
If you like the solution, please feel free to merge into MARS.

Best regards, 
Bjørn