### PR TITLE
Prevent NPE when TValue is empty

### DIFF
--- a/Source/MARS.Core.JSON.pas
+++ b/Source/MARS.Core.JSON.pas
@@ -287,12 +287,12 @@ var
   LTypeName: string;
   LVariantValue: Variant;
 begin
+  if AValue.IsEmpty and not AValue.IsArray then
+    exit(TJSONNull.Create);
+
   LTypeName := string(AValue.TypeInfo^.Name);
 
-  if AValue.IsEmpty and not AValue.IsArray then
-    Result := TJSONNull.Create
-
-  else if (AValue.Kind in [tkString, tkUString, tkChar, {$ifdef DelphiXE6_UP} tkWideChar, {$endif} tkLString, tkWString])  then
+  if (AValue.Kind in [tkString, tkUString, tkChar, {$ifdef DelphiXE6_UP} tkWideChar, {$endif} tkLString, tkWString])  then
     Result := TJSONString.Create(AValue.AsString)
 
   else if IsDictionaryOfStringAndT(LTypeName) then


### PR DESCRIPTION
When a TValue is empty/null and it is serialized to Json, a NullPointerException occurs. This is because the serialization method does access the TypeInfo, which is null.