### PR TITLE
Fixed missing PATCH method in Access-Control-Allow-Methods if CORS is…

### DIFF
--- a/Source/MARS.Core.Engine.pas
+++ b/Source/MARS.Core.Engine.pas
@@ -298,7 +298,7 @@ begin
     Exit;
 
   SetHeaderFromParameter('Access-Control-Allow-Origin', 'CORS.Origin', '*');
-  SetHeaderFromParameter('Access-Control-Allow-Methods', 'CORS.Methods', 'HEAD,GET,PUT,POST,DELETE,OPTIONS');
+  SetHeaderFromParameter('Access-Control-Allow-Methods', 'CORS.Methods', 'HEAD,GET,PUT,POST,PATCH,DELETE,OPTIONS');
   SetHeaderFromParameter('Access-Control-Allow-Headers', 'CORS.Headers', 'X-Requested-With,Content-Type,Authorization');
 end;
 


### PR DESCRIPTION
The "Access-Control-Allow-Methods" header sent when CORS is enabled is missing the 'PATCH' command.
Fixes #135