### PR TITLE
fix delphi version

### DIFF
--- a/ThirdParty/mORMot/Source/SynCommons.pas
+++ b/ThirdParty/mORMot/Source/SynCommons.pas
@@ -13278,7 +13278,7 @@ type
   {$ifdef MSWINDOWS}
   THeapMemoryStream = class(TMemoryStream)
   protected
-    function Realloc(var NewCapacity: {$if defined(VER350)} NativeInt {$else} LongInt {$ifend}): Pointer; override;
+    function Realloc(var NewCapacity: {$if CompilerVersion >= 35} NativeInt {$else} LongInt {$ifend}): Pointer; override;
   end;
   {$else}
   THeapMemoryStream = TMemoryStream;
@@ -38681,7 +38681,7 @@ end;
 const
   MemoryDelta = $8000; // 32 KB granularity (must be a power of 2)
 
-function THeapMemoryStream.Realloc(var NewCapacity: {$if defined(VER350)} NativeInt {$else} LongInt {$ifend}): Pointer;
+function THeapMemoryStream.Realloc(var NewCapacity: {$if CompilerVersion >= 35} NativeInt {$else} LongInt {$ifend}): Pointer;
 // allocates memory from Delphi heap (FastMM4/SynScaleMM) and not windows.Global*()
 // and uses bigger growing size -> a lot faster
 var i: PtrInt;


### PR DESCRIPTION
Error when compile on Delphi 12.

The problem is source:
ThirdParty/mORMot/Source/SynCommons.pas

It have defined(VER350) but in delphi 12 is VER360.

In order to work in Alexandria too, i suggest used "CompilerVersion >= 35".