### PR TITLE
- Fix #141 and others

### DIFF
--- a/Source/MARS.Core.Activation.Interfaces.pas
+++ b/Source/MARS.Core.Activation.Interfaces.pas
@@ -22,6 +22,7 @@ type
 
     procedure Invoke;
 
+    function GetId: string;
     function GetApplication: TMARSApplication;
     function GetEngine: TMARSEngine;
     function GetInvocationTime: TStopwatch;
@@ -43,6 +44,7 @@ type
     function GetURLPrototype: TMARSURL;
     function GetToken: TMARSToken;
 
+    property Id: string read GetId;
     property Application: TMARSApplication read GetApplication;
     property Engine: TMARSEngine read GetEngine;
     property InvocationTime: TStopwatch read GetInvocationTime;

--- a/Source/MARS.Core.Activation.pas
+++ b/Source/MARS.Core.Activation.pas
@@ -43,6 +43,7 @@ type
 
   TMARSActivation = class(TInterfacedObject, IMARSActivation)
   private
+    FId: string;
     FRequest: IMARSRequest;
     FResponse: IMARSResponse;
     class var FBeforeInvokeProcs: TArray<TMARSBeforeInvokeProc>;
@@ -106,6 +107,7 @@ type
     function HasToken: Boolean; virtual;
     procedure Invoke; virtual;
 
+    function GetId: string; inline;
     function GetApplication: TMARSApplication; inline;
     function GetEngine: TMARSEngine; inline;
     function GetInvocationTime: TStopwatch; inline;
@@ -128,6 +130,7 @@ type
     function GetToken: TMARSToken; inline;
     // ---
 
+    property Id: string read FId;
     property Application: TMARSApplication read FApplication;
     property Engine: TMARSEngine read FEngine;
     property InvocationTime: TStopwatch read FInvocationTime;
@@ -764,6 +767,11 @@ begin
   Result := FEngine;
 end;
 
+function TMARSActivation.GetId: string;
+begin
+  Result := FId;
+end;
+
 function TMARSActivation.GetInvocationTime: TStopwatch;
 begin
   Result := FInvocationTime;
@@ -780,6 +788,8 @@ begin
   FRequest := ARequest;
   FResponse := AResponse;
   FURL := AURL;
+
+  FId := TGUID.NewGuid.ToString;
 
   FURLPrototype := nil;
   FToken := nil;

--- a/Source/MARS.Core.Attributes.pas
+++ b/Source/MARS.Core.Attributes.pas
@@ -22,6 +22,8 @@ uses
 type
   MARSAttribute = class(TCustomAttribute);
 
+  NoLogAttribute = class(MARSAttribute);
+
   PathAttribute = class(MARSAttribute)
   private
     FValue: string;

--- a/Source/MARS.http.Server.Indy.pas
+++ b/Source/MARS.http.Server.Indy.pas
@@ -100,6 +100,8 @@ type
     procedure RedirectTo(const AURL: string);
     // -------------------------------------------------------------------------
     constructor Create(AWebResponse: TWebResponse); virtual;
+
+    property WebResponse: TWebResponse read FWebResponse;
   end;
 
   TMARSIdHTTPAppRequest = class(TIdHTTPAppRequest)


### PR DESCRIPTION
- Fix #141 
- Activation: added an ID. You are able to log request and response and match one-to-one
- Attibutes: added "NoLog" attribute: if a resource or method has this attribute, the resource or method will not be logged
- ResReqLogger.Memory: fix compilation and new properties
- Server.Indy: TMARSWebResponse expose TWebResponse
