### PR TITLE
Added support for the Access-Control-Allow-Private-Network header, on…

### DIFF
--- a/Source/MARS.Core.Engine.pas
+++ b/Source/MARS.Core.Engine.pas
@@ -312,6 +312,7 @@ begin
   SetHeaderFromParameter('Access-Control-Allow-Origin', 'CORS.Origin', '*');
   SetHeaderFromParameter('Access-Control-Allow-Methods', 'CORS.Methods', 'HEAD,GET,PUT,POST,PATCH,DELETE,OPTIONS');
   SetHeaderFromParameter('Access-Control-Allow-Headers', 'CORS.Headers', 'X-Requested-With,Content-Type,Authorization');
+  SetHeaderFromParameter('Access-Control-Allow-Private-Network', 'CORS.PrivateNetwork', 'true');
 end;
 
 function TMARSEngine.GetAfterHandleRequest: TAfterHandleRequestProc;


### PR DESCRIPTION
Support for the Access-Control-Allow-Private-Network header has been added. This is available exclusively in the CORS context and is governed by the CORS.PrivateNetwork parameter.